### PR TITLE
Fix alt:V - ZoneManager image

### DIFF
--- a/dist/resources.json
+++ b/dist/resources.json
@@ -23,7 +23,7 @@
 			"javascript",
 			"utility"
 		],
-		"cover": "https://imgur.com/a/6mrH2My",
+		"cover": "https://i.imgur.com/STiydsz.png",
 		"cli": false,
 		"author": "resources/Phill030",
 		"updated": "2022-01-09T10:42:10.000Z",


### PR DESCRIPTION
# Please double check your fork for the following:

- [X] Creating this pull request.
- [X] Cover image is uploaded on imgur.
- [X] Cover image ends in `.jpg, .png, or .jpeg`
- [X] Tags of resources only includes tags supplied on front-page

**Fill each step with 'X' if requirements are met.**
