### PR TITLE
Remove deprecated esbuild dev plugin, add altv-esbuild

### DIFF
--- a/resources/xshady/altv-esbuild.json
+++ b/resources/xshady/altv-esbuild.json
@@ -1,0 +1,7 @@
+{
+  "title": "esbuild dev and prod plugin",
+  "url": "https://github.com/xxshady/altv-esbuild",
+  "description": "alt:V esbuild plugin to simplify development and production",
+  "tags": ["javascript", "typescript", "tool"],
+  "cover": "https://i.imgur.com/spCngWE.jpg"
+}

--- a/resources/xshady/esbuild-plugin-dev-server.json
+++ b/resources/xshady/esbuild-plugin-dev-server.json
@@ -1,7 +1,0 @@
-{
-  "title": "[JS/TS] Esbuild dev plugin",
-  "url": "https://github.com/xxshady/esbuild-plugin-altv-dev-server",
-  "description": "esbuild plugin for extremely fast scripting using JS/TS on alt:V.",
-  "tags": ["javascript", "typescript", "tool"],
-  "cover": "https://i.imgur.com/spCngWE.jpg"
-}


### PR DESCRIPTION
# Please double check your fork for the following:

- [X] Creating this pull request.
- [X] Cover image is uploaded on imgur.
- [X] Cover image ends in `.jpg, .png, or .jpeg`
- [X] Tags of resources only includes tags supplied on front-page

**Fill each step with 'X' if requirements are met.**
